### PR TITLE
Fix Ray Lightning trainer invocation

### DIFF
--- a/src/train.ipynb
+++ b/src/train.ipynb
@@ -95,13 +95,14 @@
     "    )\n",
     "\n",
     "    trainer = RayLightningTrainer(\n",
+    "        train_loop_per_worker=train_func,\n",
     "        scaling_config=scaling_config,\n",
     "        run_config=None,\n",
     "        lightning_config={},\n",
     "        trainer_init_config={},\n",
     "    )\n",
     "\n",
-    "    trainer.fit(train_func)\n"
+    "    trainer.fit()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- update RayLightningTrainer call to use `train_loop_per_worker=train_func`
- invoke `trainer.fit()` without passing train function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596923cbd88331b7e6d8ba17edb699